### PR TITLE
Switch to gulp-merge-media-queries.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var gulp = require('gulp'),
     concat = require('gulp-concat'),
     rename = require('gulp-rename'),
     cssmin = require('gulp-cssmin'),
-    cmq = require('gulp-combine-media-queries');
+    mmq = require('gulp-merge-media-queries');
 	
 gulp.task('bundle-minify-js', function () {
   return gulp.src(['assets/js/classie.js', 'assets/js/main.js', 'assets/js/sponsorship.js', 'assets/js/disqus.js'])
@@ -21,10 +21,10 @@ gulp.task('bundle-minify-google-analytics', function () {
 
 gulp.task('styles-build', function() {
   return gulp.src('assets/css/main.css')
-    .pipe(cmq())
+    .pipe(mmq())
 	.pipe(cssmin())
     .pipe(rename({suffix: '.min'}))
-    .pipe(gulp.dest('assets/css'));
-})
+    .pipe(gulp.dest('assets/css'))
+});
 
 gulp.task('default', ['bundle-minify-js', 'bundle-minify-google-analytics', 'styles-build']);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.4",
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-combine-media-queries": "^0.2.0",
+    "gulp-merge-media-queries": "^0.2.0",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
gulp-combine-media-queries seems to be unmaintained now, and produces
a TypeError on current Node.js and Gulp versions.

See https://github.com/konitter/gulp-combine-media-queries/issues/19 for
discussion.

Tag @troyhunt 