### PR TITLE
Fix responsive nav hamburger menu cutting off menu items

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1223,7 +1223,7 @@ th, td
   text-decoration: none;
 }
 
-@media (min-width:0)and (max-width:50em)
+@media (min-width:0) and (max-width:50em)
 {
   .header_navMenu
   {
@@ -1241,7 +1241,7 @@ th, td
     top: 0;
     left: -100px;
     width: 0;
-    height: 100%;
+    height: 100vh;
     background-color: rgba(44,42,36,.98);
     opacity: 0;
     z-index: 9;


### PR DESCRIPTION
The current responsive nav seems to "work" on:
* iOS Safari/Chrome/Firefox/Edge
* Android Edge/Firefox
* Windows Firefox Responsive Simulator

But not on:
* Android Chrome/Samsung Internet
* Windows Chrome/Edge Responsive Simulator

In the "broken" browsers, opening the responsive hamburger menu causes the Home / Workshops / Speaking links to get cut off by the top of the screen.

![Windows Chrome Responsive Simulator](https://user-images.githubusercontent.com/19152062/113597580-42c2ae80-967f-11eb-81cb-a032b96e8982.png) ![Google Pixel Chrome](https://user-images.githubusercontent.com/19152062/113597590-46563580-967f-11eb-90d4-2131ab538350.png)


It seems to come down to [browser difference](https://stackoverflow.com/questions/35532987/heights-rendering-differently-in-chrome-and-firefox/35537510#answer-35537510:~:text=When%20working%20with%20flexbox%2C%20Chrome%20and,IE11%2FEdge%20prioritize%20the%20parent's%20flex%20height.) in how they interpret a percentage height, where mobile Chrome and the others listed in "not working" are taking the 100% of the parent (div.header)'s height, 44px, for div.header_navMenu_wrap's height, hence the cut off menu items.

Changing `.header_navMenu_wrap`'s (when responsive) `height` to `100vh` sets it to 100% of the viewport height instead, matching what's already happening on iOS.